### PR TITLE
Add guidelines link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ Documentation related to podified controlplane.
 * [Quickstart guide to start a new operator](new_operator.md)
 * [Conditions usage](conditions.md)
 * [Common issues](common_issues.md)
+* [Implementation Guidelines](developer.md)


### PR DESCRIPTION
We are missing the link to the developer guidelines in the README file.