### PR TITLE
Update instructions for running local operator

### DIFF
--- a/running_local_operator.md
+++ b/running_local_operator.md
@@ -21,7 +21,7 @@ local operator will resolve its CR.
 
 ```
 oc get csv -n openstack-operators <your operator CSV> -o json | \
-  jq -r 'del(.metadata.generation, .metadata.resourceVersion)'  > operator_csv.json
+  jq -r 'del(.metadata.generation, .metadata.resourceVersion, .metadata.uid)'  > operator_csv.json
 ```
 
 2. Either patch the CSV for the operator so that it scales down to 0 controller-manager pod replicas:


### PR DESCRIPTION
Update the instructions for creating a backup of the operator's CSV. The command needs to remove the /metadata/uid because that field is immutable.