### PR TITLE
Update Ceph docs for OpenStackDataPlaneNodeSet

### DIFF
--- a/ceph.md
+++ b/ceph.md
@@ -161,24 +161,23 @@ spec:
             mountPath: "/etc/ceph"
             readOnly: true
 ```
-The `OpenStackDataPlane` can also use `extraMounts`.
+The `OpenStackDataPlaneNodeSet` can also use `extraMounts`.
 ```yaml
 apiVersion: dataplane.openstack.org/v1beta1
-kind: OpenStackDataPlane
+kind: OpenStackDataPlaneNodeSet
 spec:
-  roles:
-    edpm-compute:
-      nodeTemplate:
-        extraMounts:
-        - extraVolType: Ceph
-          volumes:
-          - name: ceph
-            secret:
-              secretName: ceph-conf-files
-          mounts:
-          - name: ceph
-            mountPath: "/etc/ceph"
-            readOnly: true
+  ...
+  nodeTemplate:
+    extraMounts:
+    - extraVolType: Ceph
+      volumes:
+      - name: ceph
+        secret:
+          secretName: ceph-conf-files
+      mounts:
+      - name: ceph
+        mountPath: "/etc/ceph"
+        readOnly: true
 ```
 When a CR containing the above is created, an Ansible pod
 running on OpenShift mounts the files in the Ceph secret
@@ -307,14 +306,14 @@ overwrite any custom service with the same name during reconciliation.
 
 After the `ConfigMap` and `OpenStackDataPlaneService` services above
 have been created (e.g. `oc create -f ceph-nova.yaml`), update the
-`OpenStackDataPlane`
+`OpenStackDataPlaneNodeSet`
 [EDPM services list](https://openstack-k8s-operators.github.io/dataplane-operator/composable_services)
 to replace the `nova` service with `nova-custom-ceph` and add the
 `ceph-client` service.
 
 ```yaml
 apiVersion: dataplane.openstack.org/v1beta1
-kind: OpenStackDataPlane
+kind: OpenStackDataPlaneNodeSet
 spec:
   ...
   roles:
@@ -495,10 +494,10 @@ spec:
 ## Full Examples
 
 The examples above are focussed on showing how a
-single `OpenStackControlPlane` and `OpenStackDataPlane`
+single `OpenStackControlPlane` and `OpenStackDataPlaneNodeSet`
 CR can be modified to include Ceph configuration by adding
 `extraMounts` and `customServiceConfig`. Links to complete
 examples are below.
 
 - `OpenStackControlPlane`: [core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml](https://github.com/openstack-k8s-operators/openstack-operator/blob/main/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml)
-- `OpenStackDataPlane`: [dataplane_v1beta1_openstackdataplane_ceph.yaml](https://github.com/openstack-k8s-operators/dataplane-operator/blob/main/config/samples/dataplane_v1beta1_openstackdataplane_ceph.yaml)
+- `OpenStackDataPlaneNodeSet`: [dataplane_v1beta1_openstackdataplanenodeset_ceph.yaml](https://github.com/openstack-k8s-operators/dataplane-operator/blob/main/config/samples/dataplane_v1beta1_openstackdataplanenodeset_ceph.yaml)

--- a/edpm_service_overview.md
+++ b/edpm_service_overview.md
@@ -71,9 +71,9 @@ ports for the Ceph Monitoring service.
     dport: [6789, 3300]
 ```
 
-When the `run-os`
-[composable service](https://openstack-k8s-operators.github.io/dataplane-operator/composable_services/)
-runs, it executes the role
+When the `configure-os` and `run-os`
+[composable services](https://openstack-k8s-operators.github.io/dataplane-operator/composable_services/)
+run, they execute the role
 [edpm_nftables](https://github.com/openstack-k8s-operators/edpm-ansible/tree/main/roles/edpm_nftables)
 This role reads files in `/var/lib/edpm-config/firewall/`
 and creates a `edpm-rules.nft` file in `/etc/nftables/` and then
@@ -94,11 +94,11 @@ which results in the following output from the NFT command.
 		tcp dport { 3300, 6789 } ct state new counter packets 0 bytes 0 accept comment "110 allow ceph_mon"
 [root@edpm-compute-0 ~]# 
 ```
-If the service needs to be deployed after the `run-os` service has
-run, then the Ansible for that service can directly call the
-`edpm_nftables` role to update the files in `/etc/nftables` and
-reload the rules. An example of this from the `edpm_libvirt` role
-is below.
+If the service needs to be deployed after the `configure-os` and
+`run-os` services have run, then the Ansible for that service can
+directly call the `edpm_nftables` role to update the files in
+`/etc/nftables` and reload the rules. An example of this from the
+`edpm_libvirt` role is below.
 
 ```yaml
 - name: Copy qemu vnc firewall config


### PR DESCRIPTION
The OpenStackDataPlaneNodeSet CRD has been introduced to the data plane operator so the Ceph documentation needs to be updated to work with the new CRD.

Also, ceph-hci-pre needs to come before configure-os, as the latter is what actually applies the firewall rules that the former generates.