### PR TITLE
Fix external RGW doc to point to keystone internal endpoint

### DIFF
--- a/ceph.md
+++ b/ceph.md
@@ -441,7 +441,8 @@ ceph config set global rgw_max_attrs_num_in_req 90
 ceph config set global rgw_max_attr_size 1024
 ```
 
-- Replace `$KEYSTONE_ENDPOINT` with the identity service public endpoint.
+- Replace `$KEYSTONE_ENDPOINT` with the identity service internal endpoint (the
+  EDPM nodes are able to resolve the internal endpoint and not the public one)
 - Replace `$SWIFT_PASSWORD` with the password assigned to the swift user in the
   previous step.
 


### PR DESCRIPTION
EDPM nodes resolve the internal endpoint associated with a given service. This change fixes the doc where we previously suggested to add the "ceph config global set rgw_keystone_url" pointing to the identity public endpoint.