### PR TITLE
Clarify that service_config is for oslo.config services

### DIFF
--- a/service_config.md
+++ b/service_config.md
@@ -15,6 +15,9 @@ converge or diverge according to a given operator, the number of deployed
 services, and other potential requirements that are not the same across the
 board.
 
+The document doesn't apply to services that do not use `oslo.config` INI-like
+configuration files (or even *any* configuration files), for example, OVN.
+
 
 ## Proposed approach
 


### PR DESCRIPTION
OVN has no use for kolla config file management. Kolla just gets in the way by putting additional requirements as to permissions on top of what OVN services actually may need.