### PR TITLE
Fix RGW/Swift section name

### DIFF
--- a/ceph.md
+++ b/ceph.md
@@ -400,7 +400,7 @@ spec:
                     cephfs_protocol_helper_type=CEPHFS
 ```
 
-## Configure Swift with a RGW backend
+## Configuring Ceph Object Store to use external Ceph Object Gateway
 
 It's possible to configure an external Ceph Object Gateway (RGW) as an Object
 Store service. Users can rely on the `Swift` client tool to interact with the


### PR DESCRIPTION
RGW is not a backend for Swift, we technically create and configure the object store service to use an external element (RGW) that exposes the same Swift API. In this scenario swift is not deployed at all via the swift-operator.