### PR TITLE
Troubleshooting: Small improvements

### DIFF
--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -10,3 +10,21 @@ container command, probes, and labels and get a shell into it. If you need to
 route traffic to the Pod then you can use `--keep-labels=true` in the
 `oc debug` command to keep the duplicated Pod as a backed of the related
 Service.
+
+The debug command can be used not only on a specific `Pod` (`oc debug
+cinder-api-0`) but also on any resource that creates pods such as
+`Deployments`, `StatefulSets`, etc. as well as `Nodes`.  For example: `oc debug
+StatefulSet/cinder-scheduler`.
+
+By default `oc debug` will run `/bin/sh` on the first container of the pod, but
+we can easily specify a different container to debug.  This is useful for pods
+like the API where the first container is tailing a file and its the second
+container the one we usually want to debug.  For example: `oc debug -c
+cinder-api pod/cinder-api-0`.
+
+We can use these last 2 functionalities, debugging non `Pod` resources and
+specifying the container, to debug Init Containers.  For example: `oc debug
+-c init Deployment/dnsmasq-dns`.
+
+Please check the `oc debug --help` output for other available functionality
+such as `--as-root`, `--as-user`, `--to-namespace`, `--node-name`, etc.


### PR DESCRIPTION
This patch makes small improvements to the `troubleshooting.md` file to briefly present some of the other possibilities of the `oc debug` command that are useful for debugging.