### PR TITLE
[b/r] Add pre-backup health check to user guide

### DIFF
--- a/backup-restore/user-guide.md
+++ b/backup-restore/user-guide.md
@@ -96,6 +96,19 @@ oc exec -n openshift-adp ${VELERO_POD} -- /velero version
 
 ## Backup Procedure
 
+### Pre-check: Verify Control Plane Health
+
+Verify that the OpenStack control plane and data plane are Ready before
+taking a backup. A backup of an unhealthy environment might restore into
+the same broken state.
+
+```bash
+oc wait openstackcontrolplane -n openstack --all \
+  --for=condition=Ready --timeout=10s
+oc wait openstackdataplanenodeset -n openstack --all \
+  --for=condition=Ready --timeout=10s
+```
+
 ### Step 1: Collect Operator Version and Backup Timestamp
 
 ```bash


### PR DESCRIPTION
Verify that control plane and data plane nodesets are Ready before taking a backup to prevent backing up a broken state.