### PR TITLE
[backup-restore] Remove redundant includedNamespaces from PVC backup hook

### DIFF
--- a/backup-restore/user-guide.md
+++ b/backup-restore/user-guide.md
@@ -208,8 +208,6 @@ spec:
   hooks:                                   # Swift xattr backup (optional, see notes)
     resources:
       - name: swift-xattr-backup
-        includedNamespaces:
-          - openstack
         labelSelector:
           matchLabels:
             component: swift-storage


### PR DESCRIPTION
The `includedNamespaces` on the swift-xattr-backup hook is redundant because the Backup CR already scopes to the `openstack` namespace via `spec.includedNamespaces`. Hooks only target pods within the backup's namespace scope regardless.